### PR TITLE
Pass dots when fitting with selected HPs

### DIFF
--- a/R/IntervalRegression.R
+++ b/R/IntervalRegression.R
@@ -349,7 +349,8 @@ IntervalRegressionCV <- structure(function
     initial.regularization=selected$regularization,
     factor.regularization=NULL,
     margin=selected$margin,
-    verbose=verbose)
+    verbose=verbose,
+    ...)
   fit$plot.selectRegularization <- fit$plot <- gg.bands
   fit$plot.selectRegularization.line <- best.margin.folds
   fit$plot.selectRegularization.ribbon <- best.margin.stats


### PR DESCRIPTION
Dots were not passed to IntervalRegressionRegularized when training with the hyper-parameter values selected during cross-validation.